### PR TITLE
Fix interacciones al cerrar notificación

### DIFF
--- a/dialogflow-android-client-master/app/src/main/java/app/hablemos/services/NotificationService.java
+++ b/dialogflow-android-client-master/app/src/main/java/app/hablemos/services/NotificationService.java
@@ -176,8 +176,10 @@ public class NotificationService {
             observacion = context.getString(R.string.interaccionTexto_CerrarNotificacionSalud);
         }
 
-        InteractionsService interactionsService = new InteractionsService(context, context.getAssets(), fbRefInteracciones);
-        interactionsService.guardarInteraccion(mailQueInicioSesion, titulo, "No", observacion);
+        if(!TextUtils.isEmpty(titulo)){
+            InteractionsService interactionsService = new InteractionsService(context, context.getAssets(), fbRefInteracciones);
+            interactionsService.guardarInteraccion(mailQueInicioSesion, titulo, "No", observacion);
+        }
     }
 
     public void registrarNotificacionVencida(Context context, int tipoNotificacion){


### PR DESCRIPTION
Se agrega un if para no guardar interacción vacía en la notificación de reporte (estaba antes y cuando cambié el código de lugar me lo comí)